### PR TITLE
Handle Namespace v1 in the uptest run

### DIFF
--- a/internal/templates/00-assert.yaml.tmpl
+++ b/internal/templates/00-assert.yaml.tmpl
@@ -10,6 +10,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.PreAssertScriptPath }}
 - command: {{ $resource.PreAssertScriptPath }}
 {{- end }}

--- a/internal/templates/01-assert.yaml.tmpl
+++ b/internal/templates/01-assert.yaml.tmpl
@@ -8,6 +8,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if not $resource.Namespace }}
 {{- if $resource.Root }}
 - script: ${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider{{ $resource.UpdateAssertKey }}}' | grep -q "^{{ $resource.UpdateAssertValue }}$"

--- a/internal/templates/01-update.yaml.tmpl
+++ b/internal/templates/01-update.yaml.tmpl
@@ -6,6 +6,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if not $resource.Namespace }}
 {{- if $resource.Root }}
 - command: ${KUBECTL} patch {{ $resource.KindGroup }}/{{ $resource.Name }} --type=merge -p '{"spec":{"forProvider":{{ $resource.UpdateParameter }}}}'

--- a/internal/templates/02-assert.yaml.tmpl
+++ b/internal/templates/02-assert.yaml.tmpl
@@ -8,6 +8,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- range $condition := $resource.Conditions }}
 {{- if not $resource.Namespace }}
 - command: ${KUBECTL} wait {{ $resource.KindGroup }}/{{ $resource.Name }} --for=condition={{ $condition }} --timeout 10s

--- a/internal/templates/02-import.yaml.tmpl
+++ b/internal/templates/02-import.yaml.tmpl
@@ -15,6 +15,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if not $resource.Namespace }}
 - script: /tmp/patch.sh {{ $resource.KindGroup }} {{ $resource.Name }}
 {{- end }}

--- a/internal/templates/03-assert.yaml.tmpl
+++ b/internal/templates/03-assert.yaml.tmpl
@@ -9,6 +9,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.Namespace }}
 - script: ${KUBECTL} wait {{ $resource.KindGroup }}/{{ $resource.Name }} --for=delete --timeout 10s --namespace {{ $resource.Namespace }}
 {{- else }}

--- a/internal/templates/03-delete.yaml.tmpl
+++ b/internal/templates/03-delete.yaml.tmpl
@@ -6,6 +6,9 @@ commands:
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}
+{{- if eq $resource.KindGroup "namespace." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.PreDeleteScriptPath }}
 - command: {{ $resource.PreDeleteScriptPath }}
 {{- end }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -43,6 +43,12 @@ type: Opaque
 data:
   key: dmFsdWU=
 `
+
+	namespaceManifest = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+`
 )
 
 func TestRender(t *testing.T) {
@@ -173,6 +179,11 @@ commands:
 						KindGroup: "secret.",
 						Namespace: "upbound-system",
 					},
+					{
+						YAML:      namespaceManifest,
+						Name:      "test-namespace",
+						KindGroup: "namespace.",
+					},
 				},
 			},
 			want: want{
@@ -182,7 +193,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - command: /tmp/setup.sh
-` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest,
+` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest + "---\n" + namespaceManifest,
 					"00-assert.yaml": `# This assert file belongs to the resource apply step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
@@ -384,6 +395,11 @@ commands:
 						KindGroup: "secret.",
 						Namespace: "upbound-system",
 					},
+					{
+						YAML:      namespaceManifest,
+						Name:      "test-namespace",
+						KindGroup: "namespace.",
+					},
 				},
 			},
 			want: want{
@@ -393,7 +409,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - command: /tmp/setup.sh
-` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest,
+` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest + "---\n" + namespaceManifest,
 					"00-assert.yaml": `# This assert file belongs to the resource apply step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
@@ -478,6 +494,11 @@ commands:
 						KindGroup: "secret.",
 						Namespace: "upbound-system",
 					},
+					{
+						YAML:      namespaceManifest,
+						Name:      "test-namespace",
+						KindGroup: "namespace.",
+					},
 				},
 			},
 			want: want{
@@ -487,7 +508,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - command: /tmp/setup.sh
-` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest,
+` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest + "---\n" + namespaceManifest,
 					"00-assert.yaml": `# This assert file belongs to the resource apply step.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

* Special skip of the Namespace object similar to Secret
* Fixes #18


I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
make test
13:39:30 [ .. ] go test unit-tests
?   	github.com/crossplane/uptest/internal/config	[no test files]
	github.com/crossplane/uptest/cmd/uptest		coverage: 0.0% of statements
	github.com/crossplane/uptest/internal		coverage: 0.0% of statements
?   	github.com/crossplane/uptest/internal/version	[no test files]
ok  	github.com/crossplane/uptest/internal/templates	(cached)	coverage: 76.5% of statements
?   	github.com/crossplane/uptest/internal/config	[no test files]
	github.com/crossplane/uptest/internal		coverage: 0.0% of statements
	github.com/crossplane/uptest/cmd/uptest		coverage: 0.0% of statements
?   	github.com/crossplane/uptest/internal/version	[no test files]
=== RUN   TestRender
=== RUN   TestRender/SuccessSingleResource
=== RUN   TestRender/SuccessMultipleResource
--- PASS: TestRender (0.00s)
    --- PASS: TestRender/SuccessSingleResource (0.00s)
    --- PASS: TestRender/SuccessMultipleResource (0.00s)
=== RUN   TestRenderWithSkipDelete
=== RUN   TestRenderWithSkipDelete/SuccessSingleResource
=== RUN   TestRenderWithSkipDelete/SkipImport
=== RUN   TestRenderWithSkipDelete/SuccessMultipleResource
--- PASS: TestRenderWithSkipDelete (0.00s)
    --- PASS: TestRenderWithSkipDelete/SuccessSingleResource (0.00s)
    --- PASS: TestRenderWithSkipDelete/SkipImport (0.00s)
    --- PASS: TestRenderWithSkipDelete/SuccessMultipleResource (0.00s)
PASS
coverage: 76.5% of statements
ok  	github.com/crossplane/uptest/internal/templates	0.566s	coverage: 76.5% of statements
13:39:35 [ OK ] go test unit-tests
```

**e2e test**

Using https://github.com/upbound/configuration-azure-network as a base sample material. Adding Namespace to the test example:

```
diff --git a/examples/network-xr.yaml b/examples/network-xr.yaml
index d05c7e4..8c84b10 100644
--- a/examples/network-xr.yaml
+++ b/examples/network-xr.yaml
@@ -6,3 +6,8 @@ spec:
   parameters:
     id: ref-azure-network-from-xr
     region: westus
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
```
and running standard `make e2e`

**Before the PR change**
Everything is ready

```
k get managed
NAME                                                     SYNCED   READY   EXTERNAL-NAME             AGE
resourcegroup.azure.upbound.io/ref-azure-network-bm8fx   True     True    ref-azure-network-bm8fx   8m35s

NAME                                                                     SYNCED   READY   EXTERNAL-NAME                    AGE
virtualnetwork.network.azure.upbound.io/ref-azure-network-from-xr-vnet   True     True    ref-azure-network-from-xr-vnet   8m35s

NAME                                                           SYNCED   READY   EXTERNAL-NAME                  AGE
subnet.network.azure.upbound.io/ref-azure-network-from-xr-sn   True     True    ref-azure-network-from-xr-sn   8m35s
```

But uptest is in endless loop waiting for Namespace readiness and never completes(until timeout failure)
```
error: timed out waiting for the condition on namespaces/test-namespace
```

**After this PR change**

I inject local uptest build from this PR into the Configuration tools cache
```
cp ~/uptest/_output/bin/darwin_arm64/uptest ./.cache/tools/darwin_arm64/uptest-v0.11.1
```

and running `make e2e` again

```
--- PASS: kuttl (269.16s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (268.66s)
PASS
14:31:06 [ OK ] running automated tests
```