### PR TITLE
fix(check-endpoints): update grep for providers

### DIFF
--- a/hack/check_endpoints.sh
+++ b/hack/check_endpoints.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function check_endpoints {
-	endpoints=( $("${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get endpoints --no-headers | grep '^provider-' | awk '{print $1}') )
+	endpoints=( $("${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get endpoints --no-headers | grep 'provider-' | awk '{print $1}') )
 	for endpoint in ${endpoints[@]}; do
 		port=$(${KUBECTL} -n "${CROSSPLANE_NAMESPACE}" get endpoints "$endpoint" -o jsonpath='{.subsets[*].ports[0].port}')
 		if [[ -z "${port}" ]]; then


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fix check-endpoints.sh when installing providers via configurations the endpoints looks like:

```
kubectl -n upbound-system get endpoints --no-headers                                       
crossplane-contrib-function-auto-ready   10.244.0.7:9443    17m
crossplane-contrib-function-kcl          10.244.0.8:9443    17m
crossplane-webhooks                      10.244.0.11:9443   17m
upbound-provider-aws-s3                  10.244.0.12:9443   16m
upbound-provider-family-aws              10.244.0.13:9443   17m
```

this part will not produce an output `kubectl -n upbound-system get endpoints --no-headers | grep '^provider-' | awk '{print $1}' 
`
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
