### PR TITLE
feat(crossplane-cli): during apply check XRs with crossplane beta trace 

### DIFF
--- a/internal/templates/00-assert.yaml.tmpl
+++ b/internal/templates/00-assert.yaml.tmpl
@@ -4,6 +4,7 @@ kind: TestAssert
 timeout: {{ .TestCase.Timeout }}
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 {{- range $resource := .Resources }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -87,6 +87,7 @@ kind: TestAssert
 timeout: 10
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 - command: ${KUBECTL} wait s3.aws.upbound.io/example-bucket --for=condition=Test --timeout 10s
@@ -200,6 +201,7 @@ kind: TestAssert
 timeout: 10
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 - command: /tmp/bucket/pre-assert.sh
@@ -319,6 +321,7 @@ kind: TestAssert
 timeout: 10
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 - command: ${KUBECTL} wait s3.aws.upbound.io/example-bucket --for=condition=Test --timeout 10s
@@ -416,6 +419,7 @@ kind: TestAssert
 timeout: 10
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 - command: /tmp/bucket/pre-assert.sh
@@ -515,6 +519,7 @@ kind: TestAssert
 timeout: 10
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
+- script: if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi
 - script: echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml
 - script: echo "Dump Claim manifests for the apply assertion step:" || ${KUBECTL} get claim --all-namespaces -o yaml
 - command: /tmp/bucket/pre-assert.sh


### PR DESCRIPTION

<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Fixes: https://github.com/upbound/official-providers-ci/issues/177

Added a option with crossplane cli to trace all  applied XRs during the assert process, making it easier to identify any resources with issues - instead searching all logs.

For compatibility, if the CROSSPLANE_CLI environment variable is not set, this command will be skipped.

Without `CROSSPLANE_CLI`: 
The trace step is skipped, and the assert proceeds with the other test steps.
```
cat Makefile
[...]
SKIP_DELETE ?=
uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
	@$(INFO) running automated tests
	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e "${UPTEST_EXAMPLE_LIST}" --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
	@$(OK) running automated tests
```

```
[...]
    logger.go:42: 17:13:44 | case/0-apply | role.iam.aws.upbound.io/configuration-aws-eks-jh67d annotated
    logger.go:42: 17:13:44 | case/0-apply | role.iam.aws.upbound.io/configuration-aws-eks-r84lv annotated
    logger.go:42: 17:13:44 | case/0-apply | openidconnectprovider.iam.aws.upbound.io/configuration-aws-eks-c5gm6 annotated
    logger.go:42: 17:13:44 | case/0-apply | running command: [sh -c if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi]
    logger.go:42: 17:13:44 | case/0-apply | running command: [sh -c echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml]
    logger.go:42: 17:13:44 | case/0-apply | Dump MR manifests for the apply assertion step:
    logger.go:42: 17:13:45 | case/0-apply | apiVersion: v1
    logger.go:42: 17:13:45 | case/0-apply | items:
    logger.go:42: 17:13:45 | case/0-apply | - apiVersion: ec2.aws.upbound.io/v1beta2
    logger.go:42: 17:13:45 | case/0-apply |   kind: Route
    logger.go:42: 17:13:45 | case/0-apply |   metadata:
[...]
```

With `CROSSPLANE_CLI`: 
The script traces each composite resource to help identify any issues during the apply step.
```
cat Makefile
[...]
SKIP_DELETE ?=
uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
	@$(INFO) running automated tests
	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) CROSSPLANE_CLI=$(CROSSPLANE_CLI) $(UPTEST) e2e "${UPTEST_EXAMPLE_LIST}" --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
	@$(OK) running automated tests
```

```
[...]
    logger.go:42: 17:14:49 | case/0-apply | role.iam.aws.upbound.io/configuration-aws-eks-r84lv annotated
    logger.go:42: 17:14:49 | case/0-apply | openidconnectprovider.iam.aws.upbound.io/configuration-aws-eks-c5gm6 annotated
    logger.go:42: 17:14:49 | case/0-apply | running command: [sh -c if [ -n "${CROSSPLANE_CLI}" ]; then ${KUBECTL} get composite --no-headers -o name | while read -r comp; do [ -n "$comp" ] && ${CROSSPLANE_CLI} beta trace "$comp"; done; fi]
    logger.go:42: 17:14:49 | case/0-apply | NAME                                                     SYNCED   READY   STATUS
    logger.go:42: 17:14:49 | case/0-apply | XEKS/configuration-aws-eks                               True     False   Creating: Unready resources: access-entry, accessPolicyAssociation
    logger.go:42: 17:14:49 | case/0-apply | ├─ SecurityGroup/configuration-aws-eks-rf92h             True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ AccessEntry/configuration-aws-eks-gt7x2               False    False   ReconcileError: ...me system:masters is invalid, it cannot start with system:  []}]
    logger.go:42: 17:14:49 | case/0-apply | ├─ AccessPolicyAssociation/configuration-aws-eks-p75g9   False    -       ReconcileError: ...enced field was empty (referenced resource may not yet be ready)
    logger.go:42: 17:14:49 | case/0-apply | ├─ Addon/configuration-aws-eks-cni-addon                 True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Addon/configuration-aws-eks-ebs-csi-addon             True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Addon/configuration-aws-eks-pod-identity-addon        True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ ClusterAuth/configuration-aws-eks-kwk7z               True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Cluster/configuration-aws-eks-tltlw                   True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ NodeGroup/configuration-aws-eks-zslkz                 True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ ProviderConfig/configuration-aws-eks                  -        -       
    logger.go:42: 17:14:49 | case/0-apply | ├─ OpenIDConnectProvider/configuration-aws-eks-c5gm6     True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Role/configuration-aws-eks-jh67d                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Role/configuration-aws-eks-r84lv                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | └─ ProviderConfig/configuration-aws-eks                  -        -       
    logger.go:42: 17:14:49 | case/0-apply | NAME                                                       SYNCED   READY   STATUS
    logger.go:42: 17:14:49 | case/0-apply | XNetwork/configuration-aws-eks                             True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ InternetGateway/configuration-aws-eks-kr8w9             True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ MainRouteTableAssociation/configuration-aws-eks-mqqpp   True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ RouteTableAssociation/configuration-aws-eks-fk88f       True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ RouteTableAssociation/configuration-aws-eks-kzk7r       True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ RouteTableAssociation/configuration-aws-eks-p8w4h       True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ RouteTableAssociation/configuration-aws-eks-px74m       True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ RouteTable/configuration-aws-eks-njz4v                  True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Route/configuration-aws-eks-gf86p                       True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ SecurityGroupRule/configuration-aws-eks-lpbvs           True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ SecurityGroupRule/configuration-aws-eks-nwr8h           True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ SecurityGroup/configuration-aws-eks-kccqv               True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Subnet/configuration-aws-eks-8gs2t                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Subnet/configuration-aws-eks-clxpj                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Subnet/configuration-aws-eks-fkndp                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | ├─ Subnet/configuration-aws-eks-ngt4k                      True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | └─ VPC/configuration-aws-eks-hwmsr                         True     True    Available
    logger.go:42: 17:14:49 | case/0-apply | running command: [sh -c echo "Dump MR manifests for the apply assertion step:"; ${KUBECTL} get managed -o yaml]
    logger.go:42: 17:14:49 | case/0-apply | Dump MR manifests for the apply assertion step:
[...]
```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
