### PR TITLE
Add new cli options: `disable-import` and `disable-update`

### DIFF
--- a/cmd/uptest/main.go
+++ b/cmd/uptest/main.go
@@ -45,6 +45,8 @@ var (
 	renderOnly         = e2e.Flag("render-only", "Only render test files. Do not run the tests.").Default("false").Bool()
 	logCollectInterval = e2e.Flag("log-collect-interval", "Specifies the interval duration for collecting logs. "+
 		"The duration should be provided in a format understood by the tool, such as seconds (s), minutes (m), or hours (h). For example, '30s' for 30 seconds, '5m' for 5 minutes, or '1h' for one hour.").Default("30s").Duration()
+	skipUpdate = e2e.Flag("skip-update", "Skip the update step of the test.").Default("false").Bool()
+	skipImport = e2e.Flag("skip-import", "Skip the import step of the test.").Default("false").Bool()
 )
 
 func main() {
@@ -95,6 +97,8 @@ func e2eTests() {
 		DefaultTimeout:           *defaultTimeout,
 		Directory:                *testDir,
 		SkipDelete:               *skipDelete,
+		SkipUpdate:               *skipUpdate,
+		SkipImport:               *skipImport,
 		OnlyCleanUptestResources: *onlyCleanUptestResources,
 		RenderOnly:               *renderOnly,
 		LogCollectionInterval:    *logCollectInterval,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,8 @@ type AutomatedTest struct {
 	DefaultConditions []string
 
 	SkipDelete bool
+	SkipUpdate bool
+	SkipImport bool
 
 	OnlyCleanUptestResources bool
 

--- a/internal/templates/03-delete.yaml.tmpl
+++ b/internal/templates/03-delete.yaml.tmpl
@@ -45,6 +45,11 @@ spec:
         for:
           deletion: {}
     {{- end }}
+    {{- if not .TestCase.OnlyCleanUptestResources }}
+    - script:
+        content: |
+          ${KUBECTL} wait managed --all --for=delete --timeout -1s
+    {{- end }}
     {{- if .TestCase.TeardownScriptPath }}
     - command:
         entrypoint: {{ .TestCase.TeardownScriptPath }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -222,6 +222,9 @@ spec:
         name: example-bucket
         for:
           deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait managed --all --for=delete --timeout -1s
 `,
 				},
 			},
@@ -435,6 +438,9 @@ spec:
         namespace: upbound-system
         for:
           deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait managed --all --for=delete --timeout -1s
     - command:
         entrypoint: /tmp/teardown.sh
 `,


### PR DESCRIPTION
### Description of your changes

This PR adds two new CLI options for disabling import and update steps: `disable-import` and `disable-update`. This PR also filters the crossplane trace logs during the setup script is running. Because during the setup script is running, the crossplane command is failing because of the resource not found error. We do not want to show this error to the user because it s a noise and temporary one.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally on the configuration packages. And a successful [uptest-run](https://github.com/sergenyalcin/official-provider-gcp/actions/runs/10614123835).
