### PR TITLE
Bump golang and golangci-lint version, fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
-  GOLANGCI_VERSION: 'v1.54.2'
+  GO_VERSION: '1.23'
+  GOLANGCI_VERSION: 'v1.61.0'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run
   # a step 'if env.XXX' != ""', so we copy these to succinctly test whether

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,9 @@
 run:
   deadline: 10m
 
-  skip-files:
-  - "zz_\\..+\\.go$"
-
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats: colored-line-number
 
 linters-settings:
   errcheck:
@@ -25,7 +22,7 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions: fmt:.*,io/ioutil:^Read.*
 
   govet:
     # report about shadowed variables
@@ -108,11 +105,12 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
@@ -130,6 +128,10 @@ linters:
 
 
 issues:
+  # Excluding files
+  exclude-files:
+    - "zz_\\..+\\.go$"
+
   # Excluding configuration per-path and per-linter
   exclude-rules:
     # Exclude some linters from running on tests files.
@@ -141,7 +143,7 @@ issues:
         - gosec
         - scopelint
         - unparam
-    
+
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer)"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ S3_BUCKET ?= crossplane.uptest.releases
 GO_REQUIRED_VERSION = 1.21
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
-# GOLANGCILINT_VERSION ?= 1.54.0
+GOLANGCILINT_VERSION ?= 1.61.0
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/uptest
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)

--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -72,7 +72,7 @@ func (p *preparer) prepareManifests() ([]config.Manifest, error) {
 	if err := os.RemoveAll(caseDirectory); err != nil {
 		return nil, errors.Wrapf(err, "cannot clean directory %s", caseDirectory)
 	}
-	if err := os.MkdirAll(caseDirectory, os.ModePerm); err != nil {
+	if err := os.MkdirAll(caseDirectory, os.ModePerm); err != nil { //nolint:gosec // directory permissions are not critical here
 		return nil, errors.Wrapf(err, "cannot create directory %s", caseDirectory)
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Currently lint on main-branch fails. I encountered these errors: 

```WARN' [config_reader] The configuration option 'run.skip-files' is deprecated, please use 'issues.exclude-files'.
WARN [config_reader] The configuration option 'output.format' is deprecated, please use 'output.formats'
WARN [config_reader] The configuration option 'linters.errcheck.ignore' is deprecated, please use 'linters.errcheck.exclude-functions'.
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.
WARN The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
ERRO [linters_context] interfacer: This linter is fully inactivated': it will not produce any reports.
```


I have:

- [/] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable test` and manual verification

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
