### PR TITLE
explicitly compose wait command

### DIFF
--- a/internal/templates/03-delete.yaml.tmpl
+++ b/internal/templates/03-delete.yaml.tmpl
@@ -35,15 +35,9 @@ spec:
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
     {{- end }}
-    - wait:
-        apiVersion: {{ $resource.APIVersion }}
-        kind: {{ $resource.Kind }}
-        name: {{ $resource.Name }}
-        {{- if $resource.Namespace }}
-        namespace: {{ $resource.Namespace }}
-        {{- end }}
-        for:
-          deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait {{ if $resource.Namespace }} --namespace {{ $resource.Namespace }}{{ end }} --for=delete {{ $resource.Kind }} {{ $resource.Name }} --timeout {{.TestCase.Timeout }}
     {{- end }}
     {{- if not .TestCase.OnlyCleanUptestResources }}
     - script:


### PR DESCRIPTION
Chainsaw has `kubectl` hardcoded, so wait fails if it is not in $PATH.
This explicitly composes the wait command, using `${KUBECTL}` for
command, consistent with other places.

Fixes #34 