### PR TITLE
explicitly compose wait command

### DIFF
--- a/internal/templates/03-delete.yaml.tmpl
+++ b/internal/templates/03-delete.yaml.tmpl
@@ -35,15 +35,9 @@ spec:
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
     {{- end }}
-    - wait:
-        apiVersion: {{ $resource.APIVersion }}
-        kind: {{ $resource.Kind }}
-        name: {{ $resource.Name }}
-        {{- if $resource.Namespace }}
-        namespace: {{ $resource.Namespace }}
-        {{- end }}
-        for:
-          deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait {{ if $resource.Namespace }}--namespace {{ $resource.Namespace }} {{ end }}--for=delete {{ $resource.KindGroup }}/{{ $resource.Name }} --timeout {{ $.TestCase.Timeout }}
     {{- end }}
     {{- if not .TestCase.OnlyCleanUptestResources }}
     - script:

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -217,12 +217,9 @@ spec:
   - name: Assert Deletion
     description: Assert deletion of resources.
     try:
-    - wait:
-        apiVersion: bucket.s3.aws.upbound.io/v1alpha1
-        kind: Bucket
-        name: example-bucket
-        for:
-          deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait --for=delete s3.aws.upbound.io/example-bucket --timeout 10m0s
     - script:
         content: |
           ${KUBECTL} wait managed --all --for=delete --timeout -1s
@@ -382,12 +379,9 @@ spec:
   - name: Assert Deletion
     description: Assert deletion of resources.
     try:
-    - wait:
-        apiVersion: bucket.s3.aws.upbound.io/v1alpha1
-        kind: Bucket
-        name: example-bucket
-        for:
-          deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait --for=delete s3.aws.upbound.io/example-bucket --timeout 10m0s
     - script:
         content: |
           ${KUBECTL} wait managed --all --for=delete --timeout -1s
@@ -592,19 +586,12 @@ spec:
   - name: Assert Deletion
     description: Assert deletion of resources.
     try:
-    - wait:
-        apiVersion: bucket.s3.aws.upbound.io/v1alpha1
-        kind: Bucket
-        name: example-bucket
-        for:
-          deletion: {}
-    - wait:
-        apiVersion: cluster.gcp.platformref.upbound.io/v1alpha1
-        kind: Cluster
-        name: test-cluster-claim
-        namespace: upbound-system
-        for:
-          deletion: {}
+    - script:
+        content: |
+          ${KUBECTL} wait --for=delete s3.aws.upbound.io/example-bucket --timeout 10m0s
+    - script:
+        content: |
+          ${KUBECTL} wait --namespace upbound-system --for=delete cluster.gcp.platformref.upbound.io/test-cluster-claim --timeout 10m0s
     - script:
         content: |
           ${KUBECTL} wait managed --all --for=delete --timeout -1s


### PR DESCRIPTION
Chainsaw has `kubectl` hardcoded, so wait fails if it is not in $PATH.
This explicitly composes the wait command, using `${KUBECTL}` for
command, consistent with other places.

Fixes https://github.com/crossplane/uptest/issues/34
