### PR TITLE
Add e2e tests for uptest and integrate the uptest with namespaced MRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,42 @@ jobs:
           flags: unittests
           file: _output/tests/linux_amd64/coverage.txt
 
+  e2e:
+    runs-on: ubuntu-22.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-unit-tests-
+
+      - name: Download Go Modules
+        run: make modules.download modules.check
+
+      - name: Run e2e Tests
+        run: make uptest-e2e
+
   publish-artifacts:
     runs-on: ubuntu-22.04
     needs: detect-noop

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,37 @@ go.cachedir:
 
 go.mod.cachedir:
 	@go env GOMODCACHE
+
+# ====================================================================================
+# E2E Testing
+
+CROSSPLANE_VERSION = 1.20.0
+CROSSPLANE_NAMESPACE = crossplane-system
+-include build/makelib/local.xpkg.mk
+
+# Run all e2e tests
+uptest-e2e: $(KIND) $(KUBECTL) $(CHAINSAW) $(CROSSPLANE_CLI) build
+	@echo "Running all e2e tests..."
+	@KIND=$(KIND) KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) PLATFORM=$(PLATFORM) ./tests/e2e/ci/test-runner.sh
+
+# Run e2e tests for provider-nop only
+uptest-e2e.nop: $(KIND) $(KUBECTL) $(CHAINSAW) $(CROSSPLANE_CLI) build
+	@echo "Running provider-nop e2e tests..."
+	@KIND=$(KIND) KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) PLATFORM=$(PLATFORM) PROVIDER=nop ./tests/e2e/ci/test-runner.sh
+
+# Run e2e tests for provider-kubernetes only
+uptest-e2e.kubernetes: $(KIND) $(KUBECTL) $(CHAINSAW) $(CROSSPLANE_CLI) build
+	@echo "Running provider-kubernetes e2e tests..."
+	@KIND=$(KIND) KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) PLATFORM=$(PLATFORM) PROVIDER=kubernetes ./tests/e2e/ci/test-runner.sh
+
+# Setup kind cluster for e2e testing
+uptest-e2e.setup:
+	@echo "Setting up kind cluster for e2e testing..."
+	@KIND=$(KIND) KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) PLATFORM=$(PLATFORM) ./tests/e2e/ci/kind-cluster.sh
+
+# Cleanup kind cluster after e2e testing
+uptest-e2e.cleanup:
+	@echo "Cleaning up kind cluster..."
+	@KIND=$(KIND) KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) PLATFORM=$(PLATFORM) kind delete cluster --name uptest-e2e || true
+
+.PHONY: e2e e2e.nop e2e.kubernetes e2e.setup e2e.cleanup

--- a/hack/patch-ns.sh
+++ b/hack/patch-ns.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function patch {
+    kindgroup=$1;
+    name=$2;
+    namespace=$3;
+    if ${KUBECTL} --subresource=status patch --namespace "$namespace" "$kindgroup/$name" --type=merge -p '{"status":{"conditions":[]}}' ; then
+        return 0;
+    else
+        return 1;
+    fi;
+};
+
+
+kindgroup=$1;
+name=$2;
+namespace=$3;
+attempt=1;
+max_attempts=10;
+while [[ $attempt -le $max_attempts ]]; do
+    if patch "$kindgroup" "$name" "$namespace"; then
+        echo "Successfully patched $kindgroup/$name";
+        ${KUBECTL} annotate --namespace "$namespace" "$kindgroup/$name" uptest-old-id=$(${KUBECTL} get --namespace "$namespace" "$kindgroup/$name" -o=jsonpath='{.status.atProvider.id}') --overwrite;
+        break;
+    else
+        printf "Retrying... (%d/%d) for %s/%s/%s\n" "$attempt" "$max_attempts" "$kindgroup" "$name" "$namespace" >&2;
+    fi;
+    ((attempt++));
+    sleep 5;
+done;
+if [[ $attempt -gt $max_attempts ]]; then
+    echo "Failed to patch $kindgroup/$name after $max_attempts attempts";
+    exit 1;
+fi;
+exit 0;

--- a/internal/templates/00-apply.yaml.tmpl
+++ b/internal/templates/00-apply.yaml.tmpl
@@ -27,10 +27,8 @@ spec:
     {{- range $i, $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
-    {{- end -}}
-    {{- if not $resource.Namespace }}
-          ${KUBECTL} annotate {{ $resource.KindGroup }}/{{ $resource.Name }} upjet.upbound.io/test=true --overwrite
     {{- end }}
+          ${KUBECTL} annotate {{ if $resource.Namespace }}--namespace {{ $resource.Namespace }} {{ end }} {{ $resource.KindGroup }}/{{ $resource.Name }} upjet.upbound.io/test=true --overwrite
     {{- end }}
   - name: Assert Status Conditions
     description: |

--- a/internal/templates/01-update.yaml.tmpl
+++ b/internal/templates/01-update.yaml.tmpl
@@ -17,14 +17,12 @@ spec:
     {{- range $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
-    {{- end -}}
-    {{- if not $resource.Namespace }}
+    {{- end }}
     {{- if $resource.Root }}
     - script:
         content: |
           ${KUBECTL} --subresource=status patch {{ $resource.KindGroup }}/{{ $resource.Name }} --type=merge -p '{"status":{"conditions":[]}}'
           ${KUBECTL} patch {{ $resource.KindGroup }}/{{ $resource.Name }} --type=merge -p '{"spec":{"forProvider":{{ $resource.UpdateParameter }}}}'
-    {{- end }}
     {{- end }}
     {{- end }}
   - name: Assert Updated Resource
@@ -34,8 +32,7 @@ spec:
     {{- range $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
-    {{- end -}}
-    {{- if not $resource.Namespace }}
+    {{- end }}
     {{- if $resource.Root }}
     try:
     - assert:
@@ -44,13 +41,15 @@ spec:
           kind: {{ $resource.Kind }}
           metadata:
             name: {{ $resource.Name }}
+            {{- if $resource.Namespace }}
+            namespace: {{ $resource.Namespace }}
+            {{- end }}
           status:
             {{- range $condition := $resource.Conditions }}
             ((conditions[?type == '{{ $condition }}'])[0]):
               status: "True"
             {{- end }}
     - script:
-        content: ${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider{{ $resource.UpdateAssertKey }}}' | grep -q "^{{ $resource.UpdateAssertValue }}$"
-    {{- end }}
+        content: ${KUBECTL} get {{ if $resource.Namespace }}--namespace {{ $resource.Namespace }} {{ end }} {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider{{ $resource.UpdateAssertKey }}}' | grep -q "^{{ $resource.UpdateAssertValue }}$"
     {{- end }}
     {{- end }}

--- a/internal/templates/02-import.yaml.tmpl
+++ b/internal/templates/02-import.yaml.tmpl
@@ -21,10 +21,8 @@ spec:
           {{- range $resource := .Resources }}
           {{- if eq $resource.KindGroup "secret." -}}
             {{continue}}
-          {{- end -}}
-          {{- if not $resource.Namespace }}
-          ${KUBECTL} annotate {{ $resource.KindGroup }}/{{ $resource.Name }} crossplane.io/paused=true --overwrite
           {{- end }}
+          ${KUBECTL} annotate {{ if $resource.Namespace }}--namespace {{ $resource.Namespace }} {{ end }} {{ $resource.KindGroup }}/{{ $resource.Name }} crossplane.io/paused=true --overwrite
           {{- end }}
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
@@ -36,6 +34,7 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
     {{- range $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
@@ -44,14 +43,15 @@ spec:
     {{- if not $resource.Namespace }}
           /tmp/patch.sh {{ $resource.KindGroup }} {{ $resource.Name }}
     {{- end }}
+    {{- if $resource.Namespace }}
+          /tmp/patch-ns.sh {{ $resource.KindGroup }} {{ $resource.Name }} {{ $resource.Namespace }}
+    {{- end }}
     {{- end }}
           {{- range $resource := .Resources }}
           {{- if eq $resource.KindGroup "secret." -}}
             {{continue}}
-          {{- end -}}
-          {{- if not $resource.Namespace }}
-          ${KUBECTL} annotate {{ $resource.KindGroup }}/{{ $resource.Name }} --all crossplane.io/paused=false --overwrite
           {{- end }}
+          ${KUBECTL} annotate {{ if $resource.Namespace }}--namespace {{ $resource.Namespace }} {{ end }} {{ $resource.KindGroup }}/{{ $resource.Name }} --all crossplane.io/paused=false --overwrite
           {{- end }}
   - name: Assert Status Conditions and IDs
     description: |
@@ -62,21 +62,22 @@ spec:
     {{- range $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
-    {{- end -}}
-    {{- if not $resource.Namespace }}
+    {{- end }}
     - assert:
         resource:
           apiVersion: {{ $resource.APIVersion }}
           kind: {{ $resource.Kind }}
           metadata:
             name: {{ $resource.Name }}
+            {{- if $resource.Namespace }}
+            namespace: {{ $resource.Namespace }}
+            {{- end }}
           status:
             {{- range $condition := $resource.Conditions }}
             ((conditions[?type == '{{ $condition }}'])[0]):
               status: "True"
             {{- end }}
-    {{- end }}
-    {{- if not (or $resource.Namespace $resource.SkipImport) }}
+    {{- if not $resource.SkipImport }}
     - assert:
         timeout: 1m
         resource:
@@ -84,6 +85,9 @@ spec:
           kind: {{ $resource.Kind }}
           metadata:
             name: {{ $resource.Name }}
+            {{- if $resource.Namespace }}
+            namespace: {{ $resource.Namespace }}
+            {{- end }}
           ("status.atProvider.id" == "metadata.annotations.uptest-old-id"): true
     {{- end }}
     {{- end }}

--- a/internal/templates/02-import.yaml.tmpl
+++ b/internal/templates/02-import.yaml.tmpl
@@ -40,11 +40,13 @@ spec:
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
     {{- end -}}
+    {{- if not $resource.SkipImport }}
     {{- if not $resource.Namespace }}
           /tmp/patch.sh {{ $resource.KindGroup }} {{ $resource.Name }}
     {{- end }}
     {{- if $resource.Namespace }}
           /tmp/patch-ns.sh {{ $resource.KindGroup }} {{ $resource.Name }} {{ $resource.Namespace }}
+    {{- end }}
     {{- end }}
     {{- end }}
           {{- range $resource := .Resources }}
@@ -63,6 +65,7 @@ spec:
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}
     {{- end }}
+    {{- if not $resource.SkipImport }}
     - assert:
         resource:
           apiVersion: {{ $resource.APIVersion }}
@@ -77,6 +80,7 @@ spec:
             ((conditions[?type == '{{ $condition }}'])[0]):
               status: "True"
             {{- end }}
+    {{- end }}
     {{- if not $resource.SkipImport }}
     - assert:
         timeout: 1m

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -103,7 +103,7 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -161,7 +161,7 @@ spec:
     try:
     - script:
         content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
     - sleep:
@@ -172,9 +172,10 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
           /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
     description: |
       Assert imported resources. Firstly check the status conditions. Then
@@ -265,7 +266,7 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -323,7 +324,7 @@ spec:
     try:
     - script:
         content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
     - sleep:
@@ -334,9 +335,10 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
           /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
     description: |
       Assert imported resources. Firstly check the status conditions. Then
@@ -418,6 +420,7 @@ spec:
 						PostAssertScriptPath: "/tmp/claim/post-assert.sh",
 						PreDeleteScriptPath:  "/tmp/claim/pre-delete.sh",
 						Conditions:           []string{"Ready", "Synced"},
+						SkipImport:           true,
 					},
 					{
 						YAML:      secretManifest,
@@ -453,7 +456,8 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -527,7 +531,8 @@ spec:
     try:
     - script:
         content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim crossplane.io/paused=true --overwrite
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
     - sleep:
@@ -538,9 +543,11 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
           /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
     description: |
       Assert imported resources. Firstly check the status conditions. Then
@@ -672,7 +679,7 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -730,7 +737,7 @@ spec:
     try:
     - script:
         content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
     - sleep:
@@ -741,9 +748,10 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
           /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
     description: |
       Assert imported resources. Firstly check the status conditions. Then
@@ -778,6 +786,7 @@ spec:
 					SetupScriptPath:    "/tmp/setup.sh",
 					TeardownScriptPath: "/tmp/teardown.sh",
 					TestDirectory:      "/tmp/test-input.yaml",
+					SkipImport:         true,
 				},
 				resources: []config.Resource{
 					{
@@ -801,6 +810,7 @@ spec:
 						PostAssertScriptPath: "/tmp/claim/post-assert.sh",
 						PreDeleteScriptPath:  "/tmp/claim/pre-delete.sh",
 						Conditions:           []string{"Ready", "Synced"},
+						SkipImport:           true,
 					},
 					{
 						YAML:      secretManifest,
@@ -836,7 +846,8 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -889,56 +900,6 @@ spec:
     description: |
       Assert update operation. Firstly check the status conditions. Then assert
       the updated field in status.atProvider.
-`,
-					"02-import.yaml": `# This file belongs to the resource import step.
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: import
-spec:
-  timeouts:
-    apply: 10m0s
-    assert: 10m0s
-    exec: 10m0s
-  steps:
-  - name: Remove State
-    description: |
-      Removes the resource statuses from MRs and controllers. For controllers
-      the scale down&up was applied. For MRs status conditions are patched.
-      Also, for the assertion step, the ID before import was stored in the
-      uptest-old-id annotation.
-    try:
-    - script:
-        content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
-          ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
-          ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
-    - sleep:
-        duration: 10s
-    - script:
-        content: |
-          ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=1 --timeout 10s
-          ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
-          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
-          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
-          /tmp/check_endpoints.sh
-          /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
-  - name: Assert Status Conditions and IDs
-    description: |
-      Assert imported resources. Firstly check the status conditions. Then
-      compare the stored ID and the new populated ID. For successful test,
-      the ID must be the same.
-    try:
-    - assert:
-        resource:
-          apiVersion: bucket.s3.aws.upbound.io/v1alpha1
-          kind: Bucket
-          metadata:
-            name: example-bucket
-          status:
-            ((conditions[?type == 'Test'])[0]):
-              status: "True"
 `,
 				},
 			},
@@ -972,6 +933,7 @@ spec:
 						PostAssertScriptPath: "/tmp/claim/post-assert.sh",
 						PreDeleteScriptPath:  "/tmp/claim/pre-delete.sh",
 						Conditions:           []string{"Ready", "Synced"},
+						SkipImport:           true,
 					},
 					{
 						YAML:      secretManifest,
@@ -1007,7 +969,8 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -1081,7 +1044,8 @@ spec:
     try:
     - script:
         content: |
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket crossplane.io/paused=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim crossplane.io/paused=true --overwrite
           ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0 --timeout 10s
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
     - sleep:
@@ -1092,9 +1056,11 @@ spec:
           ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
           /tmp/patch.sh s3.aws.upbound.io example-bucket
-          ${KUBECTL} annotate s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
     description: |
       Assert imported resources. Firstly check the status conditions. Then
@@ -1172,6 +1138,7 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.
@@ -1256,7 +1223,8 @@ spec:
     - script:
         content: |
           echo "Runnning annotation script"
-          ${KUBECTL} annotate xnetwork.gcp.platformref.upbound.io/test-network-xr upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim upjet.upbound.io/test=true --overwrite
+          ${KUBECTL} annotate  xnetwork.gcp.platformref.upbound.io/test-network-xr upjet.upbound.io/test=true --overwrite
   - name: Assert Status Conditions
     description: |
       Assert applied resources. First, run the pre-assert script if exists.

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -239,7 +239,7 @@ func (t *Tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 					log.Println("Skipping import step because the root resource has disable import annotation")
 					tc.SkipImport = true
 				}
-				if updateParameter == "" || obj.GetNamespace() != "" {
+				if updateParameter == "" {
 					log.Println("Skipping update step because the root resource does not have the update parameter")
 					tc.SkipUpdate = true
 				}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,77 @@
+# Uptest End-to-End Tests
+
+This directory contains end-to-end tests for the uptest tool itself. These tests validate uptest's functionality by running it against test providers in a real Kubernetes environment.
+
+## Overview
+
+The E2E tests use two test providers to validate different uptest capabilities:
+
+- **provider-nop**: A minimal provider that simulates resource lifecycle without external dependencies
+- **provider-kubernetes**: A provider that manages native Kubernetes resources
+
+## Test Structure
+
+```
+tests/e2e/
+├── provider-nop/           # Tests using provider-nop
+│   ├── manifests/          # Test manifests
+│   ├── setup.sh           # Provider setup script
+│   └── run-tests.sh       # Test runner
+├── provider-kubernetes/    # Tests using provider-kubernetes  
+│   ├── manifests/          # Test manifests
+│   ├── setup.sh           # Provider setup script
+│   └── run-tests.sh       # Test runner
+├── ci/                    # CI integration scripts
+│   ├── kind-cluster.sh    # Kind cluster setup
+│   └── test-runner.sh     # Main test orchestrator
+└── README.md              # This file
+```
+
+## Running Tests
+
+### Prerequisites
+
+- Docker
+- kubectl
+- helm
+- kind
+- chainsaw
+- crossplane-cli
+
+### Quick Start
+
+Run all E2E tests:
+```bash
+make uptest-e2e
+```
+
+Run tests for specific provider:
+```bash
+make uptest-e2e.nop           # Provider-nop only
+make uptest-e2e.kubernetes    # Provider-kubernetes only
+```
+
+### Manual Testing
+
+1. Setup kind cluster:
+```bash
+make uptest-e2e.setup
+```
+
+2. Run specific provider tests:
+```bash
+cd tests/e2e/provider-nop
+./run-tests.sh
+```
+
+3. Cleanup:
+```bash
+make uptest-e2e.cleanup
+```
+
+### Environment Variables
+
+- `CLUSTER_NAME`: Kind cluster name (default: `uptest-e2e`)
+- `PROVIDER`: Provider to test (`nop`, `kubernetes`, or `all`)
+- `PLATFORM`: Target platform for uptest binary (used in build path)
+- `K8S_VERSION`: Kubernetes version to use (default: `v1.28.0`)

--- a/tests/e2e/ci/kind-cluster.sh
+++ b/tests/e2e/ci/kind-cluster.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-uptest-e2e}"
+K8S_VERSION="${K8S_VERSION:-v1.28.0}"
+
+echo "Setting up kind cluster for uptest e2e tests..."
+
+# Create kind cluster if it doesn't exist
+if ! ${KIND} get clusters | grep -q "^${CLUSTER_NAME}$"; then
+    echo "Creating kind cluster: ${CLUSTER_NAME}"
+    cat <<EOF | ${KIND} create cluster --name ${CLUSTER_NAME} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:${K8S_VERSION}
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8080
+  - containerPort: 443
+    hostPort: 8443
+EOF
+else
+    echo "Kind cluster ${CLUSTER_NAME} already exists"
+fi
+
+# Set kubectl context
+${KUBECTL} config use-context kind-${CLUSTER_NAME}
+
+# Wait for cluster to be ready
+echo "Waiting for cluster to be ready..."
+${KUBECTL} wait --for=condition=Ready nodes --all --timeout=300s
+
+echo "Kind cluster ${CLUSTER_NAME} is ready!"
+echo "Cluster info:"
+${KUBECTL} cluster-info

--- a/tests/e2e/ci/test-runner.sh
+++ b/tests/e2e/ci/test-runner.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+CLUSTER_NAME="${CLUSTER_NAME:-uptest-e2e}"
+PROVIDER="${PROVIDER:-all}"
+
+echo "Running uptest e2e tests..."
+echo "Provider: $PROVIDER"
+echo "Cluster: $CLUSTER_NAME"
+
+# Setup kind cluster
+echo "=== Setting up kind cluster ==="
+"$SCRIPT_DIR/kind-cluster.sh"
+
+# Build uptest
+echo "=== Building uptest ==="
+ROOT_DIR="$E2E_DIR/../../"
+cd "$ROOT_DIR"
+make build
+UPTEST_BIN="$ROOT_DIR/_output/bin/${PLATFORM}/uptest"
+export UPTEST_BIN
+
+# Function to run tests for a provider
+run_provider_tests() {
+    local provider_name=$1
+    local provider_dir="$E2E_DIR/provider-$provider_name"
+    
+    if [ ! -d "$provider_dir" ]; then
+        echo "Provider directory not found: $provider_dir"
+        return 1
+    fi
+    
+    echo "=== Running $provider_name tests ==="
+    cd "$provider_dir"
+    ./run-tests.sh
+}
+
+# Function to cleanup cluster
+cleanup_cluster() {
+    echo "=== Cleaning up cluster ==="
+    if ${KIND} get clusters | grep -q "^${CLUSTER_NAME}$"; then
+        ${KIND} delete cluster --name ${CLUSTER_NAME}
+        echo "Cluster ${CLUSTER_NAME} deleted"
+    fi
+}
+
+# Set trap to cleanup on exit
+trap cleanup_cluster EXIT
+
+# Run tests based on provider selection
+case "$PROVIDER" in
+    "nop")
+        run_provider_tests "nop"
+        ;;
+    "kubernetes")
+        run_provider_tests "kubernetes"
+        ;;
+    "all")
+        run_provider_tests "nop"
+        run_provider_tests "kubernetes"
+        ;;
+    *)
+        echo "Unknown provider: $PROVIDER"
+        echo "Available providers: nop, kubernetes, all"
+        exit 1
+        ;;
+esac
+
+echo "All e2e tests completed successfully!"

--- a/tests/e2e/provider-kubernetes/manifests/multi-objects.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/multi-objects.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: test-multi-configmap-1
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-multi-configmap-1
+        namespace: default
+      data:
+        config1: "value1"
+  providerConfigRef:
+    name: default
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: test-multi-configmap-2
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-multi-configmap-2
+        namespace: default
+      data:
+        config2: "value2"
+  providerConfigRef:
+    name: default

--- a/tests/e2e/provider-kubernetes/manifests/simple-configmap-ns.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/simple-configmap-ns.yaml
@@ -1,0 +1,21 @@
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: test-simple-configmap-ns
+  namespace: crossplane-system
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-configmap-ns
+        namespace: crossplane-system
+      data:
+        key1: "value1"
+        key2: "value2"
+  providerConfigRef:
+    name: cluster
+    kind: ClusterProviderConfig

--- a/tests/e2e/provider-kubernetes/manifests/simple-configmap.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/simple-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: test-simple-configmap
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-configmap
+        namespace: default
+      data:
+        key1: "value1"
+        key2: "value2"

--- a/tests/e2e/provider-kubernetes/run-tests.sh
+++ b/tests/e2e/provider-kubernetes/run-tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/../../../"
+UPTEST_BIN="$ROOT_DIR/_output/bin/${PLATFORM}/uptest"
+
+echo "Running provider-kubernetes e2e tests with uptest..."
+
+# Build uptest
+echo "Building uptest..."
+cd "$ROOT_DIR"
+make build
+
+echo "Using uptest binary: $UPTEST_BIN"
+
+# Test 1: Simple ConfigMap test
+echo "=== Test 1: Simple ConfigMap test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=120s \
+    "manifests/simple-configmap.yaml"
+
+# Test 2: Multi-objects test
+echo "=== Test 2: Multi-objects test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=120s \
+    "manifests/multi-objects.yaml"
+
+# Test 3: Skip delete test
+echo "=== Test 3: Skip delete test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --skip-delete \
+    --default-timeout=120s \
+    "manifests/simple-configmap.yaml"
+
+# Test 4: Skip import and update test
+echo "=== Test 4: Skip import and update test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --skip-import \
+    --skip-update \
+    --default-timeout=120s \
+    "manifests/simple-configmap.yaml"
+
+echo "All provider-kubernetes e2e tests completed successfully!"

--- a/tests/e2e/provider-kubernetes/setup.sh
+++ b/tests/e2e/provider-kubernetes/setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Setting up provider-kubernetes for uptest e2e tests..."
+
+# Install Crossplane if not already installed
+if ! ${KUBECTL} get crd compositeresourcedefinitions.apiextensions.crossplane.io &> /dev/null; then
+    echo "Installing Crossplane..."
+    ${KUBECTL} create namespace crossplane-system || true
+    helm repo add crossplane-stable https://charts.crossplane.io/stable
+    helm repo update
+    helm install crossplane crossplane-stable/crossplane \
+        --namespace crossplane-system \
+        --create-namespace \
+        --wait
+    
+    echo "Waiting for Crossplane to be ready..."
+    ${KUBECTL} wait --for=condition=ready pod -l app=crossplane --namespace=crossplane-system --timeout=300s
+fi
+
+# Install provider-kubernetes
+echo "Installing provider-kubernetes..."
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.0.0
+EOF
+
+# Wait for provider to be healthy
+echo "Waiting for provider-kubernetes to be ready..."
+${KUBECTL} wait --for=condition=healthy provider/provider-kubernetes --timeout=300s
+
+echo "Creating ProviderConfig for provider-kubernetes..."
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: InjectedIdentity
+EOF
+
+echo "Creating ClusterProviderConfig for provider-kubernetes..."
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: ClusterProviderConfig
+metadata:
+  name: cluster
+spec:
+  credentials:
+    source: InjectedIdentity
+EOF
+
+# Create crossplane-system namespace for namespaced resources
+${KUBECTL} create namespace crossplane-system || true
+
+echo "Provider-kubernetes setup completed successfully!"

--- a/tests/e2e/provider-nop/manifests/basic-resource.yaml
+++ b/tests/e2e/provider-nop/manifests/basic-resource.yaml
@@ -1,0 +1,18 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: ClusterNopResource
+metadata:
+  name: test-basic-resource
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    conditionAfter:
+    - time: 10s
+      conditionType: "Ready"
+      conditionStatus: "True"
+    - time: 15s
+      conditionType: "Synced" 
+      conditionStatus: "True"
+  writeConnectionSecretsToRef:
+    name: test-basic-resource-conn
+    namespace: crossplane-system

--- a/tests/e2e/provider-nop/manifests/conditions-test.yaml
+++ b/tests/e2e/provider-nop/manifests/conditions-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: ClusterNopResource
+metadata:
+  name: test-conditions-resource
+  annotations:
+    uptest.upbound.io/timeout: "90"
+    uptest.upbound.io/conditions: "Ready,Synced,UpToDate"
+spec:
+  forProvider:
+    conditionAfter:
+    - time: 10s
+      conditionType: "Ready"
+      conditionStatus: "True"
+    - time: 20s
+      conditionType: "Synced" 
+      conditionStatus: "True"
+    - time: 30s
+      conditionType: "UpToDate"
+      conditionStatus: "True"
+  writeConnectionSecretsToRef:
+    name: test-conditions-resource-conn
+    namespace: crossplane-system

--- a/tests/e2e/provider-nop/manifests/multi-resource.yaml
+++ b/tests/e2e/provider-nop/manifests/multi-resource.yaml
@@ -1,0 +1,37 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: ClusterNopResource
+metadata:
+  name: test-multi-resource-1
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    conditionAfter:
+    - time: 5s
+      conditionType: "Ready"
+      conditionStatus: "True"
+    - time: 10s
+      conditionType: "Synced" 
+      conditionStatus: "True"
+  writeConnectionSecretsToRef:
+    name: test-multi-resource-1-conn
+    namespace: crossplane-system
+---
+apiVersion: nop.crossplane.io/v1alpha1
+kind: ClusterNopResource
+metadata:
+  name: test-multi-resource-2
+  annotations:
+    uptest.upbound.io/timeout: "60"
+spec:
+  forProvider:
+    conditionAfter:
+    - time: 8s
+      conditionType: "Ready"
+      conditionStatus: "True"
+    - time: 15s
+      conditionType: "Synced" 
+      conditionStatus: "True"
+  writeConnectionSecretsToRef:
+    name: test-multi-resource-2-conn
+    namespace: crossplane-system

--- a/tests/e2e/provider-nop/manifests/timeout-test.yaml
+++ b/tests/e2e/provider-nop/manifests/timeout-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: ClusterNopResource
+metadata:
+  name: test-timeout-resource
+  annotations:
+    uptest.upbound.io/timeout: "30"
+spec:
+  forProvider:
+    conditionAfter:
+    - time: 5s
+      conditionType: "Ready"
+      conditionStatus: "True"
+    - time: 10s
+      conditionType: "Synced" 
+      conditionStatus: "True"
+  writeConnectionSecretsToRef:
+    name: test-timeout-resource-conn
+    namespace: crossplane-system

--- a/tests/e2e/provider-nop/run-tests.sh
+++ b/tests/e2e/provider-nop/run-tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/../../../"
+UPTEST_BIN="$ROOT_DIR/_output/bin/${PLATFORM}/uptest"
+
+echo "Running provider-nop e2e tests with uptest..."
+
+# Build uptest
+echo "Building uptest..."
+cd "$ROOT_DIR"
+make build
+
+echo "Using uptest binary: $UPTEST_BIN"
+
+# Test 1: Basic resource test
+echo "=== Test 1: Basic resource test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=120s \
+    "manifests/basic-resource.yaml"
+
+# Test 2: Timeout test
+echo "=== Test 2: Timeout test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=60s \
+    "manifests/timeout-test.yaml"
+
+# Test 3: Custom conditions test
+echo "=== Test 3: Custom conditions test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=120s \
+    "manifests/conditions-test.yaml"
+
+# Test 4: Multi-resource test
+echo "=== Test 4: Multi-resource test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --default-timeout=120s \
+    "manifests/multi-resource.yaml"
+
+# Test 5: Skip delete test
+echo "=== Test 5: Skip delete test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --skip-delete \
+    --default-timeout=120s \
+    "manifests/basic-resource.yaml"
+
+# Test 6: Render only test
+echo "=== Test 6: Render only test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --render-only \
+    --default-timeout=120s \
+    "manifests/basic-resource.yaml"
+
+# Test 7: Skip import and update test
+echo "=== Test 7: Skip import and update test ==="
+cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
+    --setup-script="setup.sh" \
+    --skip-import \
+    --skip-update \
+    --default-timeout=120s \
+    "manifests/basic-resource.yaml"
+
+echo "All provider-nop e2e tests completed successfully!"

--- a/tests/e2e/provider-nop/setup.sh
+++ b/tests/e2e/provider-nop/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Setting up provider-nop for uptest e2e tests..."
+
+# Install Crossplane if not already installed
+if ! ${KUBECTL} get crd compositeresourcedefinitions.apiextensions.crossplane.io &> /dev/null; then
+    echo "Installing Crossplane..."
+    ${KUBECTL} create namespace crossplane-system || true
+    helm repo add crossplane-stable https://charts.crossplane.io/stable
+    helm repo update
+    helm install crossplane crossplane-stable/crossplane \
+        --namespace crossplane-system \
+        --create-namespace \
+        --wait
+    
+    echo "Waiting for Crossplane to be ready..."
+    ${KUBECTL} wait --for=condition=ready pod -l app=crossplane --namespace=crossplane-system --timeout=300s
+fi
+
+# Install provider-nop
+echo "Installing provider-nop..."
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.5.0
+EOF
+
+# Wait for provider to be healthy
+echo "Waiting for provider-nop to be ready..."
+${KUBECTL} wait --for=condition=healthy provider/provider-nop --timeout=300s
+
+# Create crossplane-system namespace for connection secrets
+${KUBECTL} create namespace crossplane-system || true
+
+echo "Provider-nop setup completed successfully!"


### PR DESCRIPTION
### Description of your changes

### Summary

This PR introduces comprehensive end-to-end testing for the uptest tool and integrates support for namespaced managed resources (MRs) in uptest operations.

### Key Changes

#### E2E Testing Framework

- Added a complete E2E test suite with two test providers:
  - provider-nop: Minimal provider for basic lifecycle validation
  - provider-kubernetes: Provider for native Kubernetes resource testing
- Integrated with CI pipeline via new GitHub Actions workflow job
- Added Make targets for flexible test execution (uptest-e2e, uptest-e2e.nop, uptest-e2e.kubernetes)
- All tests are automatically run in CI and can be executed locally:
  - `make uptest-e2e`           # All tests
  - `make uptest-e2e.nop`       # Provider-nop only  
  - `make uptest-e2e.kubernetes` # Provider-kubernetes only

#### Namespaced MR Support

- Updated YAML templates (00-apply.yaml.tmpl, 01-update.yaml.tmpl, 02-import.yaml.tmpl) to handle namespaced resources
- Added hack/patch-ns.sh script for patching namespaced resources with retry logic
- Modified kubectl commands to include `--namespace` flags when resources are namespaced

#### ⚠️ Claim/Configuration Package Testing Changes

- Breaking Change: Removed automatic MR/Claim differentiation based on namespace scoping
- Previously, uptest distinguished between Claims (namespaced) and MRs (cluster-scoped) to conditionally execute update/import operations
- This assumption is no longer valid since MRs can now be namespaced
- Action Required: Users must explicitly use `--skip-import` and `--skip-update` CLI options for Claim/XR/Configuration package testing.
- Templates now execute update/import operations for all resources unless explicitly skipped via `SkipImport` and `SkipUpdate` field

#### Some Technical Details

- CI Integration: New e2e job in GitHub Actions workflow
- Template Changes:
  - Fixed annotation commands to properly handle both cluster-scoped and namespaced resources
  - Removed {{- if not $resource.Namespace }} conditionals from update/import templates
  - Import assertions now check `SkipImport` field instead of namespace presence
- Documentation: Comprehensive E2E testing guide in tests/e2e/README.md

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with newly added e2e tests and locally on provider-upjet-oci.

Example e2e run: https://github.com/crossplane/uptest/actions/runs/17620185015/job/50063696268?pr=44
