### PR TITLE
fix(v2): bump module version for v2.0.0

### DIFF
--- a/cmd/uptest/main.go
+++ b/cmd/uptest/main.go
@@ -12,7 +12,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/crossplane/uptest/pkg"
+	"github.com/crossplane/uptest/v2/pkg"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CC0-1.0
 
-module github.com/crossplane/uptest
+module github.com/crossplane/uptest/v2
 
 go 1.24.6
 

--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -23,7 +23,7 @@ import (
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 
-	"github.com/crossplane/uptest/internal/config"
+	"github.com/crossplane/uptest/v2/internal/config"
 )
 
 var (

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 
-	"github.com/crossplane/uptest/internal/config"
+	"github.com/crossplane/uptest/v2/internal/config"
 )
 
 var fileTemplates = map[string]string{

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/crossplane/uptest/internal/config"
+	"github.com/crossplane/uptest/v2/internal/config"
 )
 
 const (

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -37,8 +37,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane/v2/cmd/crank/beta/trace"
 
-	"github.com/crossplane/uptest/internal/config"
-	"github.com/crossplane/uptest/internal/templates"
+	"github.com/crossplane/uptest/v2/internal/config"
+	"github.com/crossplane/uptest/v2/internal/templates"
 )
 
 var testFiles = []string{

--- a/pkg/runner.go
+++ b/pkg/runner.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 
-	"github.com/crossplane/uptest/internal"
-	"github.com/crossplane/uptest/internal/config"
+	"github.com/crossplane/uptest/v2/internal"
+	"github.com/crossplane/uptest/v2/internal/config"
 )
 
 // RunTest runs the specified automated test


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
this will fix the following issue:

```
go mod tidy
go: errors parsing go.mod:
go.mod:25:2: require github.com/crossplane/uptest: version "v2.0.0" invalid: should be v0 or v1, not v2
```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
