### PR TITLE
Add a sync point before apply step

### DIFF
--- a/internal/templates/00-apply.yaml.tmpl
+++ b/internal/templates/00-apply.yaml.tmpl
@@ -19,6 +19,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: {{ .TestCase.TestDirectory }}
     - script:

--- a/internal/templates/02-import.yaml.tmpl
+++ b/internal/templates/02-import.yaml.tmpl
@@ -44,6 +44,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
     {{- range $resource := .Resources }}
     {{- if eq $resource.KindGroup "secret." -}}
       {{continue}}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -98,6 +98,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -182,6 +190,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
           /tmp/patch.sh s3.aws.upbound.io example-bucket
           ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
@@ -269,6 +278,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -353,6 +370,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
           /tmp/patch.sh s3.aws.upbound.io example-bucket
           ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
@@ -467,6 +485,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -569,6 +595,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
           /tmp/patch.sh s3.aws.upbound.io example-bucket
           ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
           ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim --all crossplane.io/paused=false --overwrite
@@ -698,6 +725,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -782,6 +817,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
           /tmp/patch.sh s3.aws.upbound.io example-bucket
           ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
   - name: Assert Status Conditions and IDs
@@ -873,6 +909,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -996,6 +1040,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -1098,6 +1150,7 @@ spec:
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch.sh -o /tmp/patch.sh && chmod +x /tmp/patch.sh
           curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/patch-ns.sh -o /tmp/patch-ns.sh && chmod +x /tmp/patch-ns.sh
           /tmp/check_endpoints.sh
+          sleep 10
           /tmp/patch.sh s3.aws.upbound.io example-bucket
           ${KUBECTL} annotate  s3.aws.upbound.io/example-bucket --all crossplane.io/paused=false --overwrite
           ${KUBECTL} annotate --namespace upbound-system  cluster.gcp.platformref.upbound.io/test-cluster-claim --all crossplane.io/paused=false --overwrite
@@ -1173,6 +1226,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:
@@ -1258,6 +1319,14 @@ spec:
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
+    - script:
+        content: |
+          echo "Checking webhook health before proceeding..."
+          curl -sL https://raw.githubusercontent.com/crossplane/uptest/main/hack/check_endpoints.sh -o /tmp/check_endpoints.sh && chmod +x /tmp/check_endpoints.sh
+          /tmp/check_endpoints.sh
+    - sleep:
+        # Wait for conversion webhook endpoints to become fully operational after health check
+        duration: 10s
     - apply:
         file: /tmp/test-input.yaml
     - script:

--- a/tests/e2e/provider-kubernetes/manifests/multi-objects.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/multi-objects.yaml
@@ -3,7 +3,7 @@ kind: Object
 metadata:
   name: test-multi-configmap-1
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:
@@ -22,7 +22,7 @@ kind: Object
 metadata:
   name: test-multi-configmap-2
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:

--- a/tests/e2e/provider-kubernetes/manifests/simple-configmap-ns.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/simple-configmap-ns.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-simple-configmap-ns
   namespace: crossplane-system
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:

--- a/tests/e2e/provider-kubernetes/manifests/simple-configmap.yaml
+++ b/tests/e2e/provider-kubernetes/manifests/simple-configmap.yaml
@@ -3,7 +3,7 @@ kind: Object
 metadata:
   name: test-simple-configmap
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:

--- a/tests/e2e/provider-kubernetes/run-tests.sh
+++ b/tests/e2e/provider-kubernetes/run-tests.sh
@@ -19,14 +19,14 @@ echo "Using uptest binary: $UPTEST_BIN"
 echo "=== Test 1: Simple ConfigMap test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/simple-configmap.yaml"
 
 # Test 2: Multi-objects test
 echo "=== Test 2: Multi-objects test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/multi-objects.yaml"
 
 # Test 3: Skip delete test
@@ -34,7 +34,7 @@ echo "=== Test 3: Skip delete test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
     --skip-delete \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/simple-configmap.yaml"
 
 # Test 4: Skip import and update test
@@ -43,7 +43,7 @@ cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
     --skip-import \
     --skip-update \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/simple-configmap.yaml"
 
 echo "All provider-kubernetes e2e tests completed successfully!"

--- a/tests/e2e/provider-nop/manifests/basic-resource.yaml
+++ b/tests/e2e/provider-nop/manifests/basic-resource.yaml
@@ -3,7 +3,7 @@ kind: ClusterNopResource
 metadata:
   name: test-basic-resource
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "120"
 spec:
   forProvider:
     conditionAfter:

--- a/tests/e2e/provider-nop/manifests/conditions-test.yaml
+++ b/tests/e2e/provider-nop/manifests/conditions-test.yaml
@@ -3,7 +3,7 @@ kind: ClusterNopResource
 metadata:
   name: test-conditions-resource
   annotations:
-    uptest.upbound.io/timeout: "90"
+    uptest.upbound.io/timeout: "120"
     uptest.upbound.io/conditions: "Ready,Synced,UpToDate"
 spec:
   forProvider:

--- a/tests/e2e/provider-nop/manifests/multi-resource.yaml
+++ b/tests/e2e/provider-nop/manifests/multi-resource.yaml
@@ -3,7 +3,7 @@ kind: ClusterNopResource
 metadata:
   name: test-multi-resource-1
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "120"
 spec:
   forProvider:
     conditionAfter:
@@ -22,7 +22,7 @@ kind: ClusterNopResource
 metadata:
   name: test-multi-resource-2
   annotations:
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "120"
 spec:
   forProvider:
     conditionAfter:

--- a/tests/e2e/provider-nop/manifests/timeout-test.yaml
+++ b/tests/e2e/provider-nop/manifests/timeout-test.yaml
@@ -3,7 +3,7 @@ kind: ClusterNopResource
 metadata:
   name: test-timeout-resource
   annotations:
-    uptest.upbound.io/timeout: "30"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     conditionAfter:

--- a/tests/e2e/provider-nop/run-tests.sh
+++ b/tests/e2e/provider-nop/run-tests.sh
@@ -19,7 +19,7 @@ echo "Using uptest binary: $UPTEST_BIN"
 echo "=== Test 1: Basic resource test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/basic-resource.yaml"
 
 # Test 2: Timeout test
@@ -33,14 +33,14 @@ cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
 echo "=== Test 3: Custom conditions test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/conditions-test.yaml"
 
 # Test 4: Multi-resource test
 echo "=== Test 4: Multi-resource test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/multi-resource.yaml"
 
 # Test 5: Skip delete test
@@ -48,7 +48,7 @@ echo "=== Test 5: Skip delete test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
     --skip-delete \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/basic-resource.yaml"
 
 # Test 6: Render only test
@@ -56,7 +56,7 @@ echo "=== Test 6: Render only test ==="
 cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
     --render-only \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/basic-resource.yaml"
 
 # Test 7: Skip import and update test
@@ -65,7 +65,7 @@ cd "$SCRIPT_DIR" && $UPTEST_BIN e2e \
     --setup-script="setup.sh" \
     --skip-import \
     --skip-update \
-    --default-timeout=120s \
+    --default-timeout=240s \
     "manifests/basic-resource.yaml"
 
 echo "All provider-nop e2e tests completed successfully!"


### PR DESCRIPTION
### Description of your changes

This PR adds a sync point before the apply step.

Summary: Adds webhook endpoint check and grace periods before resource operations in test templates to prevent race conditions with conversion webhooks to the before apply step.

Conversion webhooks may pass basic health checks but not be fully ready for actual conversion requests, leading to flaky test failures. These sync points ensure webhooks are operational before proceeding with resource operations.

Changes
- 00-apply.yaml.tmpl: Added webhook endpoint check script and 10s sleep before applying resources
- 02-import.yaml.tmpl: Added 10s sleep after existing webhook endpoint check before import operations
- Refactored the internal e2e tests' timeout since the new 20s time added with sleeps.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.