### PR TITLE
Add crossplane-cli trace log support for namespaced MRs

### DIFF
--- a/internal/tester.go
+++ b/internal/tester.go
@@ -255,6 +255,10 @@ func logCollectorLibraryMode(done chan bool, ticker *time.Ticker, mutex sync.Loc
 					Output:   "wide",
 				}
 
+				if r.Namespace != "" {
+					traceCmd.Namespace = r.Namespace
+				}
+
 				if err := traceCmd.Run(kongCtx, logger); err != nil {
 					continue
 				}
@@ -277,7 +281,11 @@ func logCollectorCLIMode(done chan bool, ticker *time.Ticker, mutex sync.Locker,
 				// We do not want to show this error to the user because it
 				// is a noise and temporary one.
 				// The error output was redirected to a file.
-				traceCmd := exec.Command("bash", "-c", fmt.Sprintf(`"${CROSSPLANE_CLI}" beta trace %s %s -o wide 2>>/tmp/uptest_crossplane_temp_errors.log`, r.KindGroup, r.Name)) //nolint:gosec // Disabling gosec to allow dynamic shell command execution
+				traceCmdArgs := fmt.Sprintf(`"${CROSSPLANE_CLI}" beta trace %s %s -o wide 2>>/tmp/uptest_crossplane_temp_errors.log`, r.KindGroup, r.Name)
+				if r.Namespace != "" {
+					traceCmdArgs = fmt.Sprintf(`"${CROSSPLANE_CLI}" beta trace %s %s -n %s -o wide 2>>/tmp/uptest_crossplane_temp_errors.log`, r.KindGroup, r.Name, r.Namespace)
+				}
+				traceCmd := exec.Command("bash", "-c", traceCmdArgs) //nolint:gosec // Disabling gosec to allow dynamic shell command execution
 				output, err := traceCmd.CombinedOutput()
 				if err == nil {
 					log.Printf("crossplane trace logs %s\n%s\n", time.Now(), string(output))


### PR DESCRIPTION
### Description of your changes

This PR adds crossplane-cli trace log support for namespaced MRs.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.

```bash
2025/10/30 17:43:39 crossplane trace logs 2025-10-30 17:43:39.255689 +0300 +03 m=+52.929388210
NAME                 RESOURCE   SYNCED   READY   STATUS
Bucket/op-pni9i8h2              True     True    Deleting

2025/10/30 17:43:39 crossplane trace logs 2025-10-30 17:43:39.295261 +0300 +03 m=+52.968960210
NAME                                     RESOURCE   SYNCED   READY   STATUS
Bucket/op-e7rotswi (crossplane-system)              True     True    Deleting
```
