### PR TITLE
feat: dedicated setup script

### DIFF
--- a/internal/templates/0-setup.yaml.tmpl
+++ b/internal/templates/0-setup.yaml.tmpl
@@ -1,0 +1,16 @@
+# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: {{ .TestCase.Timeout }}
+  steps:
+  {{- if .TestCase.SetupScriptPath }}
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: {{ .TestCase.SetupScriptPath }}
+  {{- end }}

--- a/internal/templates/0-setup.yaml.tmpl.license
+++ b/internal/templates/0-setup.yaml.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: CC0-1.0

--- a/internal/templates/00-apply.yaml.tmpl
+++ b/internal/templates/00-apply.yaml.tmpl
@@ -9,13 +9,6 @@ spec:
     assert: {{ .TestCase.Timeout }}
     exec: {{ .TestCase.Timeout }}
   steps:
-  {{- if .TestCase.SetupScriptPath }}
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: {{ .TestCase.SetupScriptPath }}
-  {{- end }}
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -6,6 +6,11 @@ package templates
 
 import _ "embed"
 
+// setupFileTemplate is the template for the setup file.
+//
+//go:embed 0-setup.yaml.tmpl
+var setupFileTemplate string
+
 // inputFileTemplate is the template for the input file.
 //
 //go:embed 00-apply.yaml.tmpl

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -16,6 +16,7 @@ import (
 )
 
 var fileTemplates = map[string]string{
+	"0-setup.yaml":   setupFileTemplate,
 	"00-apply.yaml":  inputFileTemplate,
 	"01-update.yaml": updateFileTemplate,
 	"02-import.yaml": importFileTemplate,
@@ -24,6 +25,8 @@ var fileTemplates = map[string]string{
 
 // Render renders the specified list of resources as a test case
 // with the specified configuration.
+//
+// nolint:gocyclo
 func Render(tc *config.TestCase, resources []config.Resource, skipDelete bool) (map[string]string, error) {
 	data := struct {
 		Resources []config.Resource
@@ -35,6 +38,11 @@ func Render(tc *config.TestCase, resources []config.Resource, skipDelete bool) (
 
 	res := make(map[string]string, len(fileTemplates))
 	for name, tmpl := range fileTemplates {
+		// Skip templates with names starting with "0-" if no setup script is set
+		if tc.SetupScriptPath == "" && strings.HasPrefix(name, "0-") {
+			continue
+		}
+
 		// Skip templates with names starting with "01-" if skipUpdate is true
 		if tc.SkipUpdate && strings.HasPrefix(name, "01-") {
 			continue

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -79,6 +79,21 @@ func TestRender(t *testing.T) {
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -90,11 +105,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -648,6 +658,21 @@ spec:
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -659,11 +684,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -979,6 +999,21 @@ func TestRenderWithSkipDelete(t *testing.T) {
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -990,11 +1025,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -1231,6 +1261,21 @@ spec:
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -1242,11 +1287,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -1385,6 +1425,21 @@ spec:
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -1396,11 +1451,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -1639,6 +1689,21 @@ spec:
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -1650,11 +1715,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:
@@ -1755,6 +1815,21 @@ spec:
 			},
 			want: want{
 				out: map[string]string{
+					"0-setup.yaml": `# This file belongs to the resource setup step.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: setup
+spec:
+  timeouts:
+    exec: 10m0s
+  steps:
+  - name: Run Setup Script
+    description: Setup the test environment by running the setup script.
+    try:
+    - command:
+        entrypoint: /tmp/setup.sh
+`,
 					"00-apply.yaml": `# This file belongs to the resource apply step.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -1766,11 +1841,6 @@ spec:
     assert: 10m0s
     exec: 10m0s
   steps:
-  - name: Run Setup Script
-    description: Setup the test environment by running the setup script.
-    try:
-    - command:
-        entrypoint: /tmp/setup.sh
   - name: Apply Resources
     description: Apply resources to the cluster.
     try:

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -42,6 +42,7 @@ import (
 )
 
 var testFiles = []string{
+	"0-setup.yaml",
 	"00-apply.yaml",
 	"01-update.yaml",
 	"02-import.yaml",


### PR DESCRIPTION
### Description of your changes
Run the setup script in a dedicated chainsaw resource at the very beginning (Before `00-apply.yaml` runs)

**Question:**
To prevent breaking changes, because someone relies on filenames, I named the chainsaw resource `0-setup.yaml`.
Alternative is to name it `00-setup.yaml` and rename all following files accordingly:  `01-apply.yaml`, `02-update.yaml`, `03-import.yaml`, `04-delete.yaml` 

Let me know if that would be the preferred way.

Fixes #56

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* UnitTests
* Testing with Provider-Keycloak
