### PR TITLE
Allow tests to be cancelled via a context in library mode

### DIFF
--- a/cmd/uptest/main.go
+++ b/cmd/uptest/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,5 +108,6 @@ func e2eTests() {
 		SetUseLibraryMode(*useLibraryMode).
 		Build()
 
-	kingpin.FatalIfError(pkg.RunTest(automatedTest), "cannot run e2e tests successfully")
+	ctx := context.Background()
+	kingpin.FatalIfError(pkg.RunTestContext(ctx, automatedTest), "cannot run e2e tests successfully")
 }

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -64,7 +64,7 @@ type Tester struct {
 }
 
 // ExecuteTests execute tests via chainsaw.
-func (t *Tester) ExecuteTests() error {
+func (t *Tester) ExecuteTests(ctx context.Context) error {
 	if err := writeTestFile(t.manifests, t.options.Directory); err != nil {
 		return errors.Wrap(err, "cannot write test manifest files")
 	}
@@ -87,21 +87,21 @@ func (t *Tester) ExecuteTests() error {
 			log.Println("Skipping test " + tf)
 			continue
 		}
-		if err := executeSingleTestFile(t, tf, timeout-time.Since(startTime), resources); err != nil {
+		if err := executeSingleTestFile(ctx, t, tf, timeout-time.Since(startTime), resources); err != nil {
 			return errors.Wrap(err, "cannot execute test "+tf)
 		}
 	}
 	return nil
 }
 
-func executeSingleTestFile(t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
+func executeSingleTestFile(ctx context.Context, t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
 	if t.options.UseLibraryMode {
-		return executeSingleTestFileLibraryMode(t, tf, timeout, resources)
+		return executeSingleTestFileLibraryMode(ctx, t, tf, timeout, resources)
 	}
-	return executeSingleTestFileCLIMode(t, tf, timeout, resources)
+	return executeSingleTestFileCLIMode(ctx, t, tf, timeout, resources)
 }
 
-func executeSingleTestFileLibraryMode(t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
+func executeSingleTestFileLibraryMode(ctx context.Context, t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
 	// Explicitly Set Controller Logger
 	// because of log.SetLogger(...) was never called;
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -170,7 +170,7 @@ func executeSingleTestFileLibraryMode(t *Tester, tf string, timeout time.Duratio
 
 	go logCollectorLibraryMode(done, ticker, &mutex, resources)
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	if err := runnerflags.SetupFlags(configuration.Spec); err != nil {
@@ -193,12 +193,12 @@ func executeSingleTestFileLibraryMode(t *Tester, tf string, timeout time.Duratio
 	return nil
 }
 
-func executeSingleTestFileCLIMode(t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
+func executeSingleTestFileCLIMode(ctx context.Context, t *Tester, tf string, timeout time.Duration, resources []config.Resource) error {
 	chainsawCommand := fmt.Sprintf(`"${CHAINSAW}" test --test-dir %s --test-file %s --skip-delete --parallel 1 2>&1`,
 		filepath.Clean(filepath.Join(t.options.Directory, caseDirectory)),
 		filepath.Clean(tf))
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bash", "-c", chainsawCommand) // #nosec G204

--- a/pkg/runner.go
+++ b/pkg/runner.go
@@ -6,6 +6,7 @@
 package pkg
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -15,8 +16,16 @@ import (
 	"github.com/crossplane/uptest/v2/internal/config"
 )
 
-// RunTest runs the specified automated test
+// RunTest runs the specified automated test.
+//
+// Deprecated: Use RunTestContext.
 func RunTest(o *config.AutomatedTest) error {
+	return RunTestContext(context.Background(), o)
+}
+
+// RunTestContext runs the specified automated test, respecting context
+// cancellation.
+func RunTestContext(ctx context.Context, o *config.AutomatedTest) error {
 	if !o.RenderOnly {
 		defer func() {
 			if err := os.RemoveAll(o.Directory); err != nil {
@@ -32,7 +41,7 @@ func RunTest(o *config.AutomatedTest) error {
 	}
 
 	// Prepare assert environment and run tests
-	if err := internal.NewTester(manifests, o).ExecuteTests(); err != nil {
+	if err := internal.NewTester(manifests, o).ExecuteTests(ctx); err != nil {
 		return errors.Wrap(err, "cannot execute tests")
 	}
 


### PR DESCRIPTION
### Description of your changes

The internals of uptest respect context cancellation, but previously it wasn't possible to pass a context in when calling uptest as a library. This meant that callers couldn't cancel tests, for example when receiving a signal.

Rename `RunTest` to `RunTestContext` and add a context argument. Make `RunTest` a wrapper that uses `context.Background()` to avoid a breaking change for any existing users, but mark the context-free version as deprecated.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Existing test suite.
- Imported into the `up` CLI to verify that cancellation works.
